### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker_deploy.yaml
+++ b/.github/workflows/docker_deploy.yaml
@@ -49,7 +49,7 @@ jobs:
           echo "steps.vars.outputs.docker_tags:" ${{ steps.vars.outputs.docker_tags }}
 
       - name: Publish Docker Github Action
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           workdir: .
           name: unfoldingword/ts_v2_catalog_backport


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore